### PR TITLE
append rust-toolchain.toml to override the toolchain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /ramdisk.img
 /disk.img
 target
+
+# skip ide files
+.idea/
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ PROFILE ?= release
 USER_PROFILE ?= release
 TRUSTED_PROFILE ?= release
 
+PROGS := shell cat ls mkdir touch rm rd stat hello ps write
+
 # NOTE: generate frame pointer for every function
 export RUSTFLAGS := ${RUSTFLAGS} -C force-frame-pointers=yes
 
@@ -81,7 +83,7 @@ disk: user_image
 	rm -rf disk
 	mkdir disk
 	redoxfs disk.img disk
-	cp user/target/${ARCH}/${USER_PROFILE}/{shell,cat,ls,mkdir,touch,rm,rd,stat,hello,ps,write} disk/
+	$(foreach P,$(PROGS), cp user/target/${ARCH}/${USER_PROFILE}/${P} disk/ ; )
 	sync
 	umount disk
 
@@ -100,7 +102,7 @@ ramdisk.img: user_image
 	dd if=/dev/zero of=ramdisk.img bs=1M count=4
 	redoxfs-mkfs ramdisk.img
 	redoxfs ramdisk.img ramdisk
-	cp user/target/${ARCH}/${USER_PROFILE}/{shell,cat,ls,mkdir,touch,rm,rd,stat,hello,ps,write} ramdisk/
+	$(foreach P,$(PROGS), cp user/target/${ARCH}/${USER_PROFILE}/${P} ramdisk/ ; )
 	sync
 	umount ramdisk
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "nightly-2023-06-15"
+components = [ "rust-src", ]
+profile = "minimal"


### PR DESCRIPTION
I add a rust-toolchain.toml file, which can set the toolchain by default. 
And fix makefile when make ramdisk.img.
